### PR TITLE
Feat: Added bump fee for RBF

### DIFF
--- a/app/src/main/java/com/goldenraven/devkitwallet/data/Wallet.kt
+++ b/app/src/main/java/com/goldenraven/devkitwallet/data/Wallet.kt
@@ -135,6 +135,12 @@ object Wallet {
         return txBuilder.finish(wallet)
     }
 
+    fun createBumpFeeTransaction(txid: String, feeRate: Float): PartiallySignedBitcoinTransaction {
+        return BumpFeeTxBuilder(txid = txid, newFeeRate = feeRate)
+            .enableRbf()
+            .finish(wallet = wallet)
+    }
+
     fun sign(psbt: PartiallySignedBitcoinTransaction) {
         wallet.sign(psbt)
     }
@@ -144,7 +150,17 @@ object Wallet {
         return signedPsbt.txid()
     }
 
-    fun getTransactions(): List<Transaction> = wallet.getTransactions()
+    fun getAllTransactions(): List<Transaction> = wallet.getTransactions()
+
+    fun getTransaction(txid: String): Transaction? {
+        val allTransactions = getAllTransactions()
+        allTransactions.forEach {
+            if ((it is Transaction.Confirmed && it.details.txid == txid) || (it is Transaction.Unconfirmed && it.details.txid == txid)) {
+                return it
+            }
+        }
+        return null
+    }
 
     fun sync() {
         Log.i(TAG, "Wallet is syncing")

--- a/app/src/main/java/com/goldenraven/devkitwallet/ui/Screen.kt
+++ b/app/src/main/java/com/goldenraven/devkitwallet/ui/Screen.kt
@@ -20,5 +20,7 @@ sealed class Screen(val route: String) {
     object HomeScreen : Screen("home_screen")
     object SendScreen : Screen("send_screen")
     object ReceiveScreen : Screen("receive_screen")
+    object RBFScreen : Screen("rbf_screen")
     object TransactionsScreen : Screen("transactions_screen")
+    object TransactionScreen : Screen("transaction_screen")
 }

--- a/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/RBFScreen.kt
+++ b/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/RBFScreen.kt
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2020-2022 thunderbiscuit and contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the ./LICENSE file.
+ */
+
+package com.goldenraven.devkitwallet.ui.wallet
+
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.navigation.NavController
+import com.goldenraven.devkitwallet.data.Wallet
+import com.goldenraven.devkitwallet.ui.Screen
+import com.goldenraven.devkitwallet.ui.theme.DevkitWalletColors
+import com.goldenraven.devkitwallet.ui.theme.firaMono
+import com.goldenraven.devkitwallet.utilities.TAG
+import org.bitcoindevkit.PartiallySignedBitcoinTransaction
+import org.bitcoindevkit.Transaction
+
+@Composable
+internal fun RBFScreen(
+    navController: NavController,
+    paddingValues: PaddingValues,
+    txid: String?,
+) {
+    if (txid.isNullOrEmpty()) {
+        navController.popBackStack()
+    }
+    var transaction: Transaction? = getTransaction(txid = txid)
+    if (transaction == null) {
+        navController.popBackStack()
+    }
+    transaction = transaction as Transaction.Unconfirmed
+    val context = LocalContext.current
+
+    val amount = transaction.details.sent.toString()
+    val feeRate: MutableState<String> = rememberSaveable { mutableStateOf(transaction.details.fee.toString()) }
+    val (showDialog, setShowDialog) =  rememberSaveable { mutableStateOf(false) }
+
+    ConstraintLayout(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+            .background(DevkitWalletColors.night4)
+    ) {
+        val (screenTitle, transactionInputs, bottomButtons) = createRefs()
+
+        Text(
+            text = "Send Bitcoin",
+            color = DevkitWalletColors.snow1,
+            fontSize = 28.sp,
+            fontFamily = firaMono,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .constrainAs(screenTitle) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+                .padding(top = 70.dp)
+        )
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.constrainAs(transactionInputs) {
+                top.linkTo(screenTitle.bottom)
+                bottom.linkTo(bottomButtons.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                height = Dimension.fillToConstraints
+            }
+        ) {
+            ShowTxnDetail(name = "Transaction Id",content = txid!!)
+            ShowTxnDetail(name = "Amount", content = amount)
+            TransactionFeeInput(feeRate = feeRate)
+            BumpFeeDialog(
+                txid = txid,
+                amount = amount,
+                feeRate = feeRate,
+                showDialog = showDialog,
+                setShowDialog = setShowDialog,
+                context = context
+            )
+        }
+        Column(
+            Modifier
+                .constrainAs(bottomButtons) {
+                    bottom.linkTo(parent.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+                .padding(bottom = 32.dp)
+        ) {
+            Button(
+                onClick = { setShowDialog(true) },
+                colors = ButtonDefaults.buttonColors(DevkitWalletColors.auroraRed),
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier
+                    .height(80.dp)
+                    .fillMaxWidth(0.9f)
+                    .padding(vertical = 8.dp, horizontal = 8.dp)
+                    .shadow(elevation = 4.dp, shape = RoundedCornerShape(16.dp))
+            ) {
+                Text(
+                    text = "broadcast transaction",
+                    fontSize = 14.sp,
+                    fontFamily = firaMono,
+                    textAlign = TextAlign.Center,
+                    lineHeight = 28.sp,
+                )
+            }
+            Button(
+                onClick = { navController.navigate(Screen.HomeScreen.route) },
+                colors = ButtonDefaults.buttonColors(DevkitWalletColors.frost4),
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier
+                    .height(80.dp)
+                    .fillMaxWidth(0.9f)
+                    .padding(vertical = 8.dp, horizontal = 8.dp)
+                    .shadow(elevation = 4.dp, shape = RoundedCornerShape(16.dp))
+            ) {
+                Text(
+                    text = "back to wallet",
+                    fontSize = 14.sp,
+                    fontFamily = firaMono,
+                    textAlign = TextAlign.Center,
+                    lineHeight = 28.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShowTxnDetail(name: String, content: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(fraction = 0.9f)
+    ) {
+        OutlinedTextField(
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+                .weight(0.5f),
+            value = content,
+            onValueChange = {  },
+            label = {
+                Text(
+                    text = name,
+                    color = DevkitWalletColors.snow1,
+                )
+            },
+            singleLine = true,
+            textStyle = TextStyle(fontFamily = firaMono, color = DevkitWalletColors.snow1),
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                focusedBorderColor = DevkitWalletColors.auroraGreen,
+                unfocusedBorderColor = DevkitWalletColors.snow1,
+                cursorColor = DevkitWalletColors.auroraGreen,
+            ),
+            enabled = false,
+        )
+    }
+}
+
+@Composable
+private fun TransactionFeeInput(feeRate: MutableState<String>) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        OutlinedTextField(
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+                .fillMaxWidth(0.9f),
+            value = feeRate.value,
+            onValueChange = { newValue: String ->
+                feeRate.value = newValue.filter { it.isDigit() }
+            },
+            singleLine = true,
+            textStyle = TextStyle(fontFamily = firaMono, color = DevkitWalletColors.snow1),
+            label = {
+                Text(
+                    text = "Fee rate",
+                    color = DevkitWalletColors.snow1,
+                )
+            },
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                focusedBorderColor = DevkitWalletColors.auroraGreen,
+                unfocusedBorderColor = DevkitWalletColors.snow1,
+                cursorColor = DevkitWalletColors.auroraGreen,
+            ),
+        )
+    }
+}
+
+@Composable
+fun BumpFeeDialog(
+    txid: String,
+    amount: String,
+    showDialog: Boolean,
+    setShowDialog: (Boolean) -> Unit,
+    context: Context,
+    feeRate: MutableState<String>,
+) {
+    if (showDialog) {
+        var confirmationText = "Confirm Transaction : \nTxid : $txid\nAmount : $amount"
+        if (feeRate.value.isNotEmpty()) {
+            confirmationText += "Fee Rate : ${feeRate.value.toULong()}"
+        }
+        AlertDialog(
+            containerColor = DevkitWalletColors.night4,
+            onDismissRequest = {},
+            title = {
+                Text(
+                    text = "Confirm transaction",
+                    color = DevkitWalletColors.snow1
+                )
+            },
+            text = {
+                Text(
+                    text = confirmationText,
+                    color = DevkitWalletColors.snow1
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (feeRate.value.isNotEmpty()) {
+                            broadcastTransaction(txid = txid, feeRate = feeRate.value.toFloat())
+                        } else {
+                            Toast.makeText(context, "Fee is empty!", Toast.LENGTH_SHORT).show()
+                        }
+                        setShowDialog(false)
+                    },
+                ) {
+                    Text(
+                        text = "Confirm",
+                        color = DevkitWalletColors.snow1
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        setShowDialog(false)
+                    },
+                ) {
+                    Text(
+                        text = "Cancel",
+                        color = DevkitWalletColors.snow1
+                    )
+                }
+            },
+        )
+    }
+}
+
+private fun broadcastTransaction(txid: String, feeRate: Float = 1F) {
+    Log.i(TAG, "Attempting to broadcast transaction with inputs: txid $txid, fee rate: $feeRate")
+    try {
+        // create, sign, and broadcast
+        val psbt: PartiallySignedBitcoinTransaction = Wallet.createBumpFeeTransaction(txid = txid, feeRate = feeRate)
+        Wallet.sign(psbt)
+        val newTxid: String = Wallet.broadcast(psbt)
+        Log.i(TAG, "Transaction was broadcast! txid: $newTxid")
+    } catch (e: Throwable) {
+        Log.i(TAG, "Broadcast error: ${e.message}")
+    }
+}

--- a/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/RBFScreen.kt
+++ b/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/RBFScreen.kt
@@ -55,8 +55,8 @@ internal fun RBFScreen(
     transaction = transaction as Transaction.Unconfirmed
     val context = LocalContext.current
 
-    val amount = transaction.details.sent.toString()
-    val feeRate: MutableState<String> = rememberSaveable { mutableStateOf(transaction.details.fee.toString()) }
+    val amount = (transaction.details.sent - transaction.details.received - (transaction.details.fee ?: 0UL)).toString()
+    val feeRate: MutableState<String> = rememberSaveable { mutableStateOf("") }
     val (showDialog, setShowDialog) =  rememberSaveable { mutableStateOf(false) }
 
     ConstraintLayout(
@@ -199,7 +199,7 @@ private fun TransactionFeeInput(feeRate: MutableState<String>) {
             textStyle = TextStyle(fontFamily = firaMono, color = DevkitWalletColors.snow1),
             label = {
                 Text(
-                    text = "Fee rate",
+                    text = "New fee rate",
                     color = DevkitWalletColors.snow1,
                 )
             },

--- a/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/TransactionScreen.kt
+++ b/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/TransactionScreen.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020-2022 thunderbiscuit and contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the ./LICENSE file.
+ */
+
+package com.goldenraven.devkitwallet.ui.wallet
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.navigation.NavController
+import com.goldenraven.devkitwallet.data.Wallet
+import com.goldenraven.devkitwallet.ui.Screen
+import com.goldenraven.devkitwallet.ui.theme.DevkitWalletColors
+import com.goldenraven.devkitwallet.ui.theme.firaMono
+import com.goldenraven.devkitwallet.utilities.timestampToString
+import org.bitcoindevkit.Transaction
+
+@Composable
+internal fun TransactionScreen(
+    navController: NavController,
+    paddingValues: PaddingValues,
+    txid: String?,
+) {
+    val transaction = getTransaction(txid = txid)
+    if (transaction == null) {
+        navController.popBackStack()
+    }
+    val transactionDetail = getTransactionDetails(transaction = transaction!!)
+
+    ConstraintLayout(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(DevkitWalletColors.night4)
+            .padding(paddingValues)
+    ) {
+        val (screenTitle, transactions, bottomButton) = createRefs()
+
+        Column(
+            modifier = Modifier
+                .constrainAs(screenTitle) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+                .padding(top = 70.dp)
+        ) {
+            Text(
+                text = "Transaction",
+                color = DevkitWalletColors.snow1,
+                fontSize = 28.sp,
+                fontFamily = firaMono,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = transactionTitle(transaction = transaction),
+                color = DevkitWalletColors.snow1,
+                fontSize = 14.sp,
+                fontFamily = firaMono,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+        }
+
+
+        LazyColumn(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.constrainAs(transactions) {
+                top.linkTo(screenTitle.bottom)
+                bottom.linkTo(bottomButton.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                height = Dimension.fillToConstraints
+            }
+        ) {
+            items(transactionDetail) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(all = 16.dp)
+                ) {
+                    Text(
+                        text = "${it.first} :",
+                        fontSize = 16.sp,
+                        fontFamily = firaMono,
+                        color = DevkitWalletColors.snow1,
+                    )
+                    Text(
+                        text = it.second,
+                        fontSize = 16.sp,
+                        fontFamily = firaMono,
+                        textAlign = TextAlign.End,
+                        color = DevkitWalletColors.snow1,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .padding(vertical = 8.dp, horizontal = 8.dp)
+                .shadow(elevation = 4.dp, shape = RoundedCornerShape(16.dp))
+                .constrainAs(bottomButton) {
+                    bottom.linkTo(parent.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+        ) {
+            if (transaction is Transaction.Unconfirmed) {
+                TransactionDetailButton(content = "increase fees", navController = navController, txid = txid)
+                Spacer(modifier = Modifier.padding(all = 8.dp))
+            }
+            TransactionDetailButton(
+                content = "back to transaction list", navController = navController, txid = null)
+        }
+    }
+}
+
+@Composable
+fun TransactionDetailButton(content: String, navController: NavController, txid: String?) {
+    Button(
+        onClick = {
+            when (content) {
+                "increase fees" -> {
+                    navController.navigate("${Screen.RBFScreen.route}/txid=$txid")
+                }
+                "back to transaction list" -> {
+                    navController.popBackStack()
+                }
+            }
+        },
+        colors = ButtonDefaults.buttonColors(DevkitWalletColors.frost4),
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier
+            .height(60.dp)
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = content,
+            fontSize = 14.sp,
+            fontFamily = firaMono,
+            textAlign = TextAlign.Center,
+            lineHeight = 28.sp,
+        )
+    }
+}
+
+fun getTransactionDetails(transaction: Transaction): List<Pair<String, String>> {
+    val transactionDetails = mutableListOf<Pair<String, String>>()
+
+    if (transaction is Transaction.Confirmed) {
+        transactionDetails.add(Pair("Status", "Confirmed"))
+        transactionDetails.add(Pair("Timestamp", transaction.confirmation.timestamp.timestampToString()))
+        transactionDetails.add(Pair("Received", transaction.details.received.toString()))
+        transactionDetails.add(Pair("Sent", transaction.details.sent.toString()))
+        transactionDetails.add(Pair("Fees", transaction.details.fee.toString()))
+        transactionDetails.add(Pair("Block", transaction.confirmation.height.toString()))
+    } else if (transaction is Transaction.Unconfirmed) {
+        transactionDetails.add(Pair("Status", "Pending"))
+        transactionDetails.add(Pair("Timestamp", "Pending"))
+        transactionDetails.add(Pair("Received", transaction.details.received.toString()))
+        transactionDetails.add(Pair("Sent", transaction.details.sent.toString()))
+        transactionDetails.add(Pair("Fees", transaction.details.fee.toString()))
+    }
+    return transactionDetails
+}
+
+fun transactionTitle(transaction: Transaction): String {
+    if (transaction is Transaction.Confirmed) {
+        return transaction.details.txid
+    }
+    return (transaction as Transaction.Unconfirmed).details.txid
+}
+
+fun getTransaction(txid: String?): Transaction? {
+    if (txid.isNullOrEmpty()) {
+        return null
+    }
+    return Wallet.getTransaction(txid = txid)
+}

--- a/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/TransactionScreen.kt
+++ b/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/TransactionScreen.kt
@@ -169,15 +169,15 @@ fun getTransactionDetails(transaction: Transaction): List<Pair<String, String>> 
     if (transaction is Transaction.Confirmed) {
         transactionDetails.add(Pair("Status", "Confirmed"))
         transactionDetails.add(Pair("Timestamp", transaction.confirmation.timestamp.timestampToString()))
-        transactionDetails.add(Pair("Received", transaction.details.received.toString()))
-        transactionDetails.add(Pair("Sent", transaction.details.sent.toString()))
+        transactionDetails.add(Pair("Received", (if (transaction.details.received < transaction.details.sent) 0 else transaction.details.received).toString()))
+        transactionDetails.add(Pair("Sent", (if (transaction.details.sent < transaction.details.received) 0 else transaction.details.sent - transaction.details.received - transaction.details.fee!!).toString()))
         transactionDetails.add(Pair("Fees", transaction.details.fee.toString()))
         transactionDetails.add(Pair("Block", transaction.confirmation.height.toString()))
     } else if (transaction is Transaction.Unconfirmed) {
         transactionDetails.add(Pair("Status", "Pending"))
         transactionDetails.add(Pair("Timestamp", "Pending"))
-        transactionDetails.add(Pair("Received", transaction.details.received.toString()))
-        transactionDetails.add(Pair("Sent", transaction.details.sent.toString()))
+        transactionDetails.add(Pair("Received", (if (transaction.details.received < transaction.details.sent) 0 else transaction.details.received).toString()))
+        transactionDetails.add(Pair("Sent", (if (transaction.details.sent < transaction.details.received) 0 else transaction.details.sent - transaction.details.received - transaction.details.fee!!).toString()))
         transactionDetails.add(Pair("Fees", transaction.details.fee.toString()))
     }
     return transactionDetails

--- a/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/WalletNavigation.kt
+++ b/app/src/main/java/com/goldenraven/devkitwallet/ui/wallet/WalletNavigation.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import com.goldenraven.devkitwallet.ui.wallet.*
 import com.goldenraven.devkitwallet.ui.wallet.HomeScreen
 import com.goldenraven.devkitwallet.ui.wallet.ReceiveScreen
 import com.goldenraven.devkitwallet.ui.wallet.SendScreen
@@ -73,6 +74,26 @@ fun WalletNavigation(paddingValues: PaddingValues) {
         ) { SendScreen(navController, paddingValues) }
 
         composable(
+            route = "${Screen.RBFScreen.route}/txid={txid}",
+            enterTransition = {
+                slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
+            },
+            exitTransition = {
+                slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
+            },
+            popEnterTransition = {
+                slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
+            },
+            popExitTransition = {
+                slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
+            }
+        ) { backStackEntry ->
+            backStackEntry.arguments?.getString("txid")?.let {
+                RBFScreen(navController, paddingValues, backStackEntry.arguments?.getString("txid"))
+            }
+        }
+
+        composable(
             route = Screen.TransactionsScreen.route,
             enterTransition = {
                 slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
@@ -87,5 +108,25 @@ fun WalletNavigation(paddingValues: PaddingValues) {
                 slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
             }
         ) { TransactionsScreen(navController, paddingValues) }
+
+        composable(
+            route = "${Screen.TransactionScreen.route}/txid={txid}",
+            enterTransition = {
+                slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
+            },
+            exitTransition = {
+                slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
+            },
+            popEnterTransition = {
+                slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
+            },
+            popExitTransition = {
+                slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
+            }
+        ) { backStackEntry ->
+            backStackEntry.arguments?.getString("txid")?.let {
+                TransactionScreen(navController, paddingValues, backStackEntry.arguments?.getString("txid"))
+            }
+        }
     }
 }


### PR DESCRIPTION
A rather big addition for adding simple bump fee feature for RBF enable transactions.

- Added new screen to view individual transactions (Goto transactions list -> click on transaction)
- Added increase fees for pending transactions
- Added screen to let users bump fees

The RBFScreen to send bump fee transactions is a scaled down version of the send screen, but I created it instead of reusing the send screen to prevent the send screen code from getting too bloated.

Since I do not know if it is possible to calculate the transaction size in bytes we cannot find the fee rate in sats/vbyte, hence I left the fees as the total fees when viewing the send bump fees transactions.

The fees shown in the bump fees screen is incorrect though, it showing total fees might imply that you have to change the total fees but it actually is still in sats/vbyte (i.e. it shows 282 (total fees) but in fact the transaction fee rate was 2 sats/vbyte)

![WhatsApp Image 2022-07-22 at 4 36 33 PM (1)](https://user-images.githubusercontent.com/24243833/180400036-ada288d8-c017-4624-b89f-a410eac9996e.jpeg)
![WhatsApp Image 2022-07-22 at 4 36 33 PM](https://user-images.githubusercontent.com/24243833/180400042-30387ffc-ec4d-409b-9615-df2a9bc56bd8.jpeg)

