### PR TITLE
Fix bug where Mnemonic type was saved instead of actual mnemonic string

### DIFF
--- a/app-simple-wallet/app/src/main/java/com/goldenraven/devkitwallet/data/Wallet.kt
+++ b/app-simple-wallet/app/src/main/java/com/goldenraven/devkitwallet/data/Wallet.kt
@@ -64,7 +64,7 @@ object Wallet {
             internalDescriptor = internalDescriptor,
         )
         Repository.saveWallet(path, externalDescriptor, internalDescriptor)
-        Repository.saveMnemonic(mnemonic.toString())
+        Repository.saveMnemonic(mnemonic.asString())
     }
 
     // only create BIP84 compatible wallets

--- a/app-simple-wallet/app/src/main/java/com/goldenraven/devkitwallet/data/Wallet.kt
+++ b/app-simple-wallet/app/src/main/java/com/goldenraven/devkitwallet/data/Wallet.kt
@@ -64,7 +64,7 @@ object Wallet {
             internalDescriptor = internalDescriptor,
         )
         Repository.saveWallet(path, externalDescriptor, internalDescriptor)
-        Repository.saveMnemonic(Mnemonic.toString())
+        Repository.saveMnemonic(mnemonic.toString())
     }
 
     // only create BIP84 compatible wallets


### PR DESCRIPTION
In Wallet.kt, function createWallet(), there was a bug when a class Mnemonic was being saved, instead of an object mnemonic of that class.

`Mnemonic.toString()`, but it should've been` mnemonic.toString()`